### PR TITLE
Set min version to 1.5.4

### DIFF
--- a/networkConfig.js
+++ b/networkConfig.js
@@ -100,7 +100,7 @@ config = {
     // Minimum version of the Hub. 
     // WARNING: If a Hub is below this version, it will not be able to start. 
     // A running hub below this version WILL SHUT DOWN!
-    minAppVersion: "1.3.3",
+    minAppVersion: "1.5.4",
     storageRegistryAddress: "0x00000000fcce7f938e7ae6d3c335bd6a1a7c593d",
     keyRegistryAddress: "0x00000000fc9e66f1c6d86d750b4af47ff0cc343d",
     idRegistryAddress: "0x00000000fcaf86937e41ba038b4fa40baa4b780a",


### PR DESCRIPTION
This deprecates old hubs that had incorrect store sizes ([PR #1306](https://github.com/farcasterxyz/hub-monorepo/pull/1306) and related fixes)