### PR TITLE
chore: Set min version to 1.10.5 for gossip fix

### DIFF
--- a/networkConfig.js
+++ b/networkConfig.js
@@ -122,7 +122,7 @@ config = {
     // Minimum version of the Hub. 
     // WARNING: If a Hub is below this version, it will not be able to start. 
     // A running hub below this version WILL SHUT DOWN!
-    minAppVersion: "1.10.0",
+    minAppVersion: "1.10.5",
     keyRegistryV2Address: "0x00000000fc1237824fb747abde0ff18990e59b7e",
     idRegistryV2Address: "0x00000000fc6c5f01fc30151999387bb99a9f489b",
     solanaVerificationsEnabled: true,


### PR DESCRIPTION
Min version to 1.10.5 so all nodes have the gossip connection timeout fix.